### PR TITLE
Оптимизация работы Composer

### DIFF
--- a/modules/PHP-7.2-FCGI/ospanel_data/default/settings.ini
+++ b/modules/PHP-7.2-FCGI/ospanel_data/default/settings.ini
@@ -49,7 +49,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-7.2/ospanel_data/default/settings.ini
+++ b/modules/PHP-7.2/ospanel_data/default/settings.ini
@@ -59,7 +59,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-7.3-FCGI/ospanel_data/default/settings.ini
+++ b/modules/PHP-7.3-FCGI/ospanel_data/default/settings.ini
@@ -49,7 +49,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-7.3/ospanel_data/default/settings.ini
+++ b/modules/PHP-7.3/ospanel_data/default/settings.ini
@@ -59,7 +59,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-7.4-FCGI/ospanel_data/default/settings.ini
+++ b/modules/PHP-7.4-FCGI/ospanel_data/default/settings.ini
@@ -49,7 +49,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-7.4/ospanel_data/default/settings.ini
+++ b/modules/PHP-7.4/ospanel_data/default/settings.ini
@@ -59,7 +59,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-8.0-FCGI/ospanel_data/default/settings.ini
+++ b/modules/PHP-8.0-FCGI/ospanel_data/default/settings.ini
@@ -49,7 +49,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-8.0/ospanel_data/default/settings.ini
+++ b/modules/PHP-8.0/ospanel_data/default/settings.ini
@@ -59,7 +59,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-8.1-FCGI/ospanel_data/default/settings.ini
+++ b/modules/PHP-8.1-FCGI/ospanel_data/default/settings.ini
@@ -49,7 +49,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-8.1/ospanel_data/default/settings.ini
+++ b/modules/PHP-8.1/ospanel_data/default/settings.ini
@@ -59,7 +59,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-8.2-FCGI/ospanel_data/default/settings.ini
+++ b/modules/PHP-8.2-FCGI/ospanel_data/default/settings.ini
@@ -49,7 +49,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-8.2/ospanel_data/default/settings.ini
+++ b/modules/PHP-8.2/ospanel_data/default/settings.ini
@@ -59,7 +59,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-8.3-FCGI/ospanel_data/default/settings.ini
+++ b/modules/PHP-8.3-FCGI/ospanel_data/default/settings.ini
@@ -49,7 +49,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-8.3/ospanel_data/default/settings.ini
+++ b/modules/PHP-8.3/ospanel_data/default/settings.ini
@@ -59,7 +59,7 @@ BLACKFIRE_CONFIG              = {root_dir}\data\{module_name}\{profile_name}\bla
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-8.4-FCGI/ospanel_data/default/settings.ini
+++ b/modules/PHP-8.4-FCGI/ospanel_data/default/settings.ini
@@ -44,7 +44,7 @@ source_dir               = {root_dir}\system\templates
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache

--- a/modules/PHP-8.4/ospanel_data/default/settings.ini
+++ b/modules/PHP-8.4/ospanel_data/default/settings.ini
@@ -54,7 +54,7 @@ source_dir               = {root_dir}\system\templates
 
 COMPOSER                      =
 COMPOSER_ALLOW_SUPERUSER      = 1
-COMPOSER_ALLOW_XDEBUG         = 0
+COMPOSER_ALLOW_XDEBUG         =
 COMPOSER_AUTH                 =
 COMPOSER_BIN_DIR              =
 COMPOSER_CACHE_DIR            = {root_dir}\data\{module_name}\{profile_name}\composer\cache


### PR DESCRIPTION
После включения XDebug Composer стал жаловаться на возможные проблемы с производительностью:
`Composer is operating slower than normal because you have Xdebug enabled. See https://getcomposer.org/xdebug`

С учётом того, что рядовому веб-разработчику вряд ли будет дело до отладки пакетного менеджера, думаю будет правильно вернуть дефолтную настройку композера, а именно перезапуск процесса с отключенным расширением XDebug:
```ini
COMPOSER_ALLOW_XDEBUG = 0
```
